### PR TITLE
Update MetaMask playground link to new API reference docs

### DIFF
--- a/developer-docs/api-1/README.md
+++ b/developer-docs/api-1/README.md
@@ -16,7 +16,7 @@ HyperPlay is a web3-native game launcher with wallet integration. The launcher a
 
 The HyperPlay API references many of the calls found in MetaMask's and geth's JSON RPC endpoints. The next sections will provide some examples.
 
-{% embed url="https://metamask.github.io/api-playground/api-documentation" %}
+{% embed url="https://docs.metamask.io/wallet/reference/json-rpc-api/" %}
 
 {% embed url="https://ethereumbuilders.gitbooks.io/guide/content/en/ethereum_json_rpc.html" %}
 

--- a/developer-docs/api/README.md
+++ b/developer-docs/api/README.md
@@ -16,7 +16,7 @@ HyperPlay is a web3-native game launcher with wallet integration. The launcher a
 
 The HyperPlay API references many of the calls found in MetaMask's and geth's JSON RPC endpoints. The next sections will provide some examples.
 
-{% embed url="https://metamask.github.io/api-playground/api-documentation" %}
+{% embed url="https://docs.metamask.io/wallet/reference/json-rpc-api/)" %}
 
 {% embed url="https://ethereumbuilders.gitbooks.io/guide/content/en/ethereum_json_rpc.html" %}
 


### PR DESCRIPTION
MetaMask has a new reference docs page that should be linked to instead. it has similar tools on it for being able to try methods out as well.